### PR TITLE
Expected scenario values isf ipr

### DIFF
--- a/R/assert_valid_indicator.R
+++ b/R/assert_valid_indicator.R
@@ -5,6 +5,7 @@ assert_valid_indicator <-
       c(
         "Capacity",
         "Capacity: installed",
+        "Demand",
         "Emission Intensity",
         "Production",
         "Sales",

--- a/R/assert_valid_indicator_for_sector.R
+++ b/R/assert_valid_indicator_for_sector.R
@@ -16,6 +16,7 @@ assert_valid_indicator_for_sector_scenario_prep <-
           ),
         "Coal" =
           c(
+            "Demand",
             "Production",
             "Supply"
           ),
@@ -25,6 +26,7 @@ assert_valid_indicator_for_sector_scenario_prep <-
           ),
         "Oil&Gas" =
           c(
+            "Demand",
             "Production",
             "Supply"
           ),

--- a/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
+++ b/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
@@ -18,7 +18,7 @@ assert_valid_value_range_for_unit_scenario_prep <-
       "Power",                  "GW",     100000,
       "Steel",        "tCO2/t Steel",          2
     )
-    # styler: no
+    # styler: on
 
     for (i in 1:nrow(value_ranges)) {
       sector_idx <- sectors == value_ranges$sector[[i]]

--- a/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
+++ b/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
@@ -5,7 +5,7 @@ assert_valid_value_range_for_unit_scenario_prep <-
     # scenarios we use
     value_ranges <- dplyr::tribble(
       ~sector,                 ~unit, ~max_value,
-      "Automotive", "# (in million)",        100,
+      "Automotive", "# (in million)",        150,
       "Automotive",          "k*veh",     200000,
       "Aviation",         "gCO2/pkm",     0.0002,
       "Cement",      "tCO2/t Cement",          1,

--- a/R/validate_intermediate_scenario_output.R
+++ b/R/validate_intermediate_scenario_output.R
@@ -100,6 +100,7 @@ validate_intermediate_scenario_output <-
         assert_valid_technology_for_sector_scenario_prep(data$technology, data$sector, add = coll)
       }
 
+      # TODO: potentially needs to check the matching scenario to avoid unexpected passes
       # valid `indicator` for `sector`
       if (all(c("indicator", "sector") %in% names(data))) {
         assert_valid_indicator_for_sector_scenario_prep(data$indicator, data$sector, add = coll)


### PR DESCRIPTION
This PR makes minor adjustments to the allowed values in the scenario data preparation.

The IPR scenario uses Demand instead of Supply as the indicator for fossil fuels. Their assumption is that these are largely interchangeable. We therefore add an additional indicator.

The IPR scenario also provides automotive trajectories until 2050. Our previous maximum value was based on IEA in 2030. As the projected sale of EVs grows drastically in the period between 2030 and 2050, we increase the maximum allowed value from 100 mio. sales a year to 150 mio. sales a year.

fyi @Antoine-Lalechere 