### PR TITLE
Bump expected steel emission intensity threshold value

### DIFF
--- a/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
+++ b/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
@@ -16,7 +16,7 @@ assert_valid_value_range_for_unit_scenario_prep <-
       "Oil&Gas",              "mb/d",        100,
       "Oil&Gas",              "mtoe",       6000,
       "Power",                  "GW",     100000,
-      "Steel",        "tCO2/t Steel",          2
+      "Steel",        "tCO2/t Steel",          2.1
     )
     # styler: on
 


### PR DESCRIPTION
ISF 2023 suggest that in 2017:
Total steel production is 2351.61 T Steel (See raw data file `S_Global`)
Total steel CO2 emissions are 4296.77706 T CO2 (See raw data file `Scope_Global`)

Meaning emission intensity ~ 2.05

Requiring a bump to this assertion value.

For posterity, this can be validated by reviewing the raw data that is frozen on Azure File Storage:

Account: `pactarawdata`, Share: `scenario-sources`, Directory: `isf_2023`

See file `S_Global` for steel production.
See file `Scope_Global` for steel emissions.

Relates to https://github.com/RMI-PACTA/pacta.scenario.preparation/pull/127