### PR TITLE
Bump allowable Oil&Gas sector mtoe values higher

### DIFF
--- a/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
+++ b/R/assert_valid_value_range_for_sector_unit_scenario_prep.R
@@ -14,9 +14,9 @@ assert_valid_value_range_for_unit_scenario_prep <-
       "HDV",                 "k*veh",     100000,
       "Oil&Gas",               "bcm",       6000,
       "Oil&Gas",              "mb/d",        100,
-      "Oil&Gas",              "mtoe",       6000,
+      "Oil&Gas",              "mtoe",       6800,
       "Power",                  "GW",     100000,
-      "Steel",        "tCO2/t Steel",          2.5
+      "Steel",        "tCO2/t Steel",        2.5
     )
     # styler: on
 


### PR DESCRIPTION
GECO2023 Reference for Oil&Gas sector mtoe in 2070 is 6711.7820

similar to #56 and #55

(also snuck in a minor whitespace formatting fix)