### PR TITLE
include recent spellings of production units in AI data

### DIFF
--- a/R/assert_valid_production_unit.R
+++ b/R/assert_valid_production_unit.R
@@ -3,14 +3,19 @@ assert_valid_production_unit <-
     allowed_strings <-
       c(
         "DWT km",
+        "dwt km",
         "GJ",
         "MW",
         "pkm",
         "tkm",
         "tonnes of cement",
+        "t cement",
         "tonnes of coal",
+        "t coal",
         "tonnes of steel",
-        "vehicles produced"
+        "t steel",
+        "vehicles produced",
+        "# vehicles"
       )
 
     msg <- "must contain only valid production units, but has additional element{?s} {.val {misses}}"


### PR DESCRIPTION
Recent versions of AI data include new spellings of production units.

``` r
library(tidyverse)
pams_path <- "~/data/pactarawdata/asset-impact/2024-02-15_AI_RMI_2023Q4/2024-02-14_AI_2023Q4_RMI-Company-Indicators.xlsx"
pams <- pacta.data.preparation::import_ar_advanced_company_indicators(pams_path)
pams %>% filter(value_type == "production") %>% select(`Asset Sector`, `Activity Unit`) %>% distinct() %>% arrange(`Asset Sector`, `Activity Unit`)
#> # A tibble: 11 × 2
#>    `Asset Sector` `Activity Unit`
#>    <fct>          <fct>          
#>  1 Aviation       pkm            
#>  2 Aviation       tkm            
#>  3 Cement         t cement       
#>  4 Coal           t coal         
#>  5 HDV            # vehicles     
#>  6 LDV            # vehicles     
#>  7 Oil&Gas        GJ             
#>  8 Power          MW             
#>  9 Power          MWh            
#> 10 Shipping       dwt km         
#> 11 Steel          t steel
```