### PR TITLE
add new emissions factor unit spellings in AI data

### DIFF
--- a/R/assert_valid_emissions_factor_unit.R
+++ b/R/assert_valid_emissions_factor_unit.R
@@ -18,7 +18,7 @@ assert_valid_emissions_factor_unit <-
         "tCO2e/t cement",
         "tonnes of CO2 per tonnes of coal",
         "tCO2e/t coal",
-        "tonnes of CO2 per tonnes of steel"
+        "tonnes of CO2 per tonnes of steel",
         "tCO2e/t steel",
       )
 

--- a/R/assert_valid_emissions_factor_unit.R
+++ b/R/assert_valid_emissions_factor_unit.R
@@ -19,7 +19,7 @@ assert_valid_emissions_factor_unit <-
         "tonnes of CO2 per tonnes of coal",
         "tCO2e/t coal",
         "tonnes of CO2 per tonnes of steel",
-        "tCO2e/t steel",
+        "tCO2e/t steel"
       )
 
     msg <- "must contain only valid emissions factor units, but has additional element{?s} {.val {misses}}"

--- a/R/assert_valid_emissions_factor_unit.R
+++ b/R/assert_valid_emissions_factor_unit.R
@@ -3,14 +3,23 @@ assert_valid_emissions_factor_unit <-
     allowed_strings <-
       c(
         "tonnes of CO2 per DWT km",
+        "tCO2/dwt km",
         "tonnes of CO2 per GJ",
+        "tCO2e/GJ",
         "tonnes of CO2 per km",
+        "tCO2/km",
         "tonnes of CO2 per MWh per year",
+        "tCO2e/MWh",
         "tonnes of CO2 per pkm",
+        "tCO2/pkm",
         "tonnes of CO2 per tkm",
+        "tCO2/tkm",
         "tonnes of CO2 per tonnes of cement",
+        "tCO2e/t cement",
         "tonnes of CO2 per tonnes of coal",
+        "tCO2e/t coal",
         "tonnes of CO2 per tonnes of steel"
+        "tCO2e/t steel",
       )
 
     msg <- "must contain only valid emissions factor units, but has additional element{?s} {.val {misses}}"


### PR DESCRIPTION
Recent AI data is using new spellings of emissions factor units.

``` r
library(tidyverse)
pams_path <- "~/data/pactarawdata/asset-impact/2024-02-15_AI_RMI_2023Q4/2024-02-14_AI_2023Q4_RMI-Company-Indicators.xlsx"
pams <- pacta.data.preparation::import_ar_advanced_company_indicators(pams_path)
pams %>% filter(value_type == "emission_intensity") %>% select(`Asset Sector`, `Activity Unit`) %>% distinct() %>% arrange(`Asset Sector`, `Activity Unit`)
#> # A tibble: 17 × 2
#>    `Asset Sector` `Activity Unit`
#>    <fct>          <fct>          
#>  1 Aviation       tCO2           
#>  2 Aviation       tCO2/pkm       
#>  3 Aviation       tCO2/tkm       
#>  4 Cement         tCO2e          
#>  5 Cement         tCO2e/t cement 
#>  6 Coal           tCO2e          
#>  7 Coal           tCO2e/t coal   
#>  8 LDV            tCO2           
#>  9 LDV            tCO2/km        
#> 10 Oil&Gas        tCO2e          
#> 11 Oil&Gas        tCO2e/GJ       
#> 12 Power          tCO2e          
#> 13 Power          tCO2e/MWh      
#> 14 Shipping       tCO2           
#> 15 Shipping       tCO2/dwt km    
#> 16 Steel          tCO2e          
#> 17 Steel          tCO2e/t steel
```